### PR TITLE
bug: 編集すると順番が入れ替わる問題に対処

### DIFF
--- a/lib/view/screens/making_screen.dart
+++ b/lib/view/screens/making_screen.dart
@@ -74,6 +74,7 @@ class MakingScreen extends HookConsumerWidget {
         onPressed: () {
           if (data) {
             final id = campe?.id;
+            final campeCreatedAt = campe?.createdAt;
             if (id == null) {
               return;
             }
@@ -81,6 +82,7 @@ class MakingScreen extends HookConsumerWidget {
                   updatedCampe: Campe(
                     id: id,
                     name: nameController.value.text,
+                    createdAt: campeCreatedAt,
                   ),
                 );
             nameController.value.clear();


### PR DESCRIPTION
updatedCampeに渡すCampeクラスにcreatedAtを追加しました。
これは新しいカンペでカンペを置き換えているために、createdAtがnullになることで起こっている問題でした。